### PR TITLE
Update CI workflow for NPM publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,4 @@ jobs:
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+        run: yarn publish --access public --provenance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,3 @@ jobs:
       - run: yarn run build
       - run: yarn run lint:ci
       - run: yarn run test
-
-      - name: Publish to NPM
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn publish --access public --provenance

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,25 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Configure Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - run: corepack enable
+      - run: yarn publish --access public --provenance


### PR DESCRIPTION
Modify the CI workflow to include the `--provenance` flag during NPM publishing.
Separate Publish and CI workflows