### PR TITLE
Switch to npm for post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -23,4 +23,4 @@ jobs:
 
       - run: corepack enable
       - run: yarn install --immutable
-      - run: yarn publish --access public --provenance
+      - run: npm publish --access public --provenance

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -23,4 +23,4 @@ jobs:
 
       - run: corepack enable
       - run: yarn install --immutable
-      - run: npm publish --access public --provenance
+      - run: yarn npm publish --access public --provenance


### PR DESCRIPTION
Replace yarn with npm in the post-release workflow to streamline package management.